### PR TITLE
add pagination to help command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,12 +1,3 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional, List
-
-    from helpers.context import PokeContext
-
 import discord
 from discord.ext.commands import cog
 
@@ -47,15 +38,15 @@ class HelpSelect(discord.ui.Select):
         await self.help_command.send_cog_help(selected, view=self.view)
 
 class FormatCogHelp(menus.ListPageSource):
-    def __init__(self, entries, ctx: PokeContext, cog: commands.Cog, per_page: Optional[int] = 5):
+    def __init__(self, entries, ctx, cog, per_page = 5):
         super().__init__(
             entries=entries,
             per_page=per_page
         )
         self.ctx = ctx
-        self.cog: commands.Cog = cog
+        self.cog = cog
     
-    async def format_page(self, menu: menus.Menu, entry: List[commands.Command]) -> discord.Embed:
+    async def format_page(self, menu, entry):
         embed = constants.Embed(
             title = f"{self.cog.qualified_name} Help!",
             description=f"Use `{self.ctx.prefix}help <command/category>` for more information."
@@ -79,7 +70,7 @@ class FormatCogHelp(menus.ListPageSource):
         return embed
 
 class FormatGroupHelp(menus.ListPageSource):
-    def __init__(self, entries, ctx: PokeContext, group: commands.Group, per_page: Optional[int] = 5):
+    def __init__(self, entries, ctx, group, per_page = 5):
         super().__init__(
             entries=entries,
             per_page=per_page

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -78,7 +78,7 @@ class FormatGroupHelp(menus.ListPageSource):
         self.ctx = ctx
         self.group = group
     
-    async def format_page(self, menu: menus.Menu, entries: List[commands.Command]) -> discord.Embed:
+    async def format_page(self, menu, entries):
         embed = constants.Embed(
             title = f"{self.group.qualified_name} Help!",
             description=f"Use `{self.ctx.prefix}help <command/category>` for more information."

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional, List
+
+    from helpers.context import PokeContext
+
 import discord
 from discord.ext.commands import cog
 
 from helpers import constants, methods, misc
-from discord.ext import commands
-
+from discord.ext import commands, menus
+from discord.ext.menus.views import ViewMenuPages
 
 class HelpSelect(discord.ui.Select):
     def __init__(self, help_command, filtered_mapping, view):
@@ -37,6 +46,68 @@ class HelpSelect(discord.ui.Select):
         selected = self.help_command.context.bot.get_cog(self.values[0])
         await self.help_command.send_cog_help(selected, view=self.view)
 
+class FormatCogHelp(menus.ListPageSource):
+    def __init__(self, entries, ctx: PokeContext, cog: commands.Cog, per_page: Optional[int] = 5):
+        super().__init__(
+            entries=entries,
+            per_page=per_page
+        )
+        self.ctx = ctx
+        self.cog: commands.Cog = cog
+    
+    async def format_page(self, menu: menus.Menu, entry: List[commands.Command]) -> discord.Embed:
+        embed = constants.Embed(
+            title = f"{self.cog.qualified_name} Help!",
+            description=f"Use `{self.ctx.prefix}help <command/category>` for more information."
+        )
+
+        embed.set_thumbnail(url=self.ctx.me.avatar.url)
+
+        for command in entry:
+            name = f"{command.name} {command.signature}"
+            value = f"{command.help or 'No help given'}"
+
+            if isinstance(command, commands.Group):
+                name = f"[Group] {name}"
+
+            embed.add_field(
+                name=name,
+                value= value,
+                inline=False
+            )
+        
+        return embed
+
+class FormatGroupHelp(menus.ListPageSource):
+    def __init__(self, entries, ctx: PokeContext, group: commands.Group, per_page: Optional[int] = 5):
+        super().__init__(
+            entries=entries,
+            per_page=per_page
+        )
+        self.ctx = ctx
+        self.group = group
+    
+    async def format_page(self, menu: menus.Menu, entries: List[commands.Command]) -> discord.Embed:
+        embed = constants.Embed(
+            title = f"{self.group.qualified_name} Help!",
+            description=f"Use `{self.ctx.prefix}help <command/category>` for more information."
+        )
+
+        embed.set_thumbnail(url=self.ctx.me.avatar.url)
+
+        for command in entries:
+            help = command.help
+        
+            if isinstance(command, commands.Group):
+                help = f"[Group] {help}"
+
+            embed.add_field(
+                name=f"{command} {command.signature}",
+                value=help,
+                inline=False
+            )
+
+        return embed
 
 class CustomHelp(commands.HelpCommand):
     current_message = None
@@ -81,26 +152,15 @@ class CustomHelp(commands.HelpCommand):
         destination = self.get_destination()
         self.current_message = await destination.send(embed=embed, view=view)
 
-    def add_commands_to_embed(self, embed, cmds):
-        for cmd in cmds:
-            help = cmd.help or "No help provided..."
-            if isinstance(cmd, commands.Group):
-                help = f"[Group] {help}"
-            embed.add_field(
-                name=self.get_command_signature(cmd), value=help, inline=False
-            )
-
     async def send_cog_help(self, cog, view=None):
-        embed = constants.Embed(title=f"{cog.qualified_name} Help!".title())
-        embed.set_thumbnail(url=self.context.me.avatar.url)
-        self.add_commands_to_embed(
-            embed, await self.filter_commands(cog.get_commands())
-        )
-        if self.current_message:
-            await self.current_message.edit(embed=embed, view=view)
-        else:
-            destination = self.get_destination()
-            await destination.send(embed=embed)
+        commands = await self.filter_commands(cog.get_commands())
+
+        if not commands:
+            return
+        
+        source = FormatCogHelp(commands, self.context, cog)
+
+        await ViewMenuPages(source=source).start(self.context)
 
     async def send_command_help(self, command):
         embed = constants.Embed(
@@ -148,13 +208,10 @@ class CustomHelp(commands.HelpCommand):
         cmds = await self.filter_commands(group.commands)
         if not cmds:
             return await self.send_command_help(group)
-        embed = constants.Embed(
-            title=self.get_command_signature(group),
-            description=f"{group.help or 'No help provided...'}\nUse `{self.context.prefix}help <command>` for more infomation",
-        )
-        self.add_commands_to_embed(embed, cmds)
-        destination = self.get_destination()
-        await destination.send(embed=embed)
+        
+        source = FormatGroupHelp(cmds, self.context, group)
+
+        await ViewMenuPages(source=source).start(self.context)
 
 
 def setup(bot):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Rapptz/discord.py
+git+https://github.com/Rapptz/discord.py.git@master
 asyncpg
 jishaku
 toml
@@ -7,3 +7,5 @@ prettytable
 psutil
 async_lru
 git+https://github.com/bijij/discord-ext-store-true
+git+https://github.com/oliver-ni/discord-ext-menus-views
+git+https://github.com/Rapptz/discord-ext-menus


### PR DESCRIPTION
this pull request adds pagination via `discord.ext.menus` to 2 parts of the help command ( `send_cog_help` and `send_group_help`).
